### PR TITLE
Workflow

### DIFF
--- a/docs/resources/job_template.md
+++ b/docs/resources/job_template.md
@@ -27,7 +27,6 @@ resource "awx_job_template" "example" {
 
 ### Required
 
-- `job_type` (String) Acceptable values are a choice of: run, or check.
 - `name` (String)
 - `playbook` (String) Playbook name to be executed by this job
 - `project` (Number) ID number of the project to associate with the job template
@@ -63,6 +62,7 @@ resource "awx_job_template" "example" {
 - `inventory` (Number) ID number of the inventory to associate with the job template. Supply this or set ask_inventory_on_launch = true.
 - `job_slice_count` (Number)
 - `job_tags` (String)
+- `job_type` (String) Acceptable values are a choice of: run, or check.
 - `limit` (String)
 - `prevent_instance_group_fallback` (Boolean)
 - `scm_branch` (String)

--- a/docs/resources/job_template_credential.md
+++ b/docs/resources/job_template_credential.md
@@ -3,27 +3,12 @@
 page_title: "awx_job_template_credential Resource - awx"
 subcategory: ""
 description: |-
-  The /api/v2/job_templates/{id}/credentials/ returns all credential objects associated to the template. But, when asked to associate a credential or
-  dissassociate a credential, you must post a request once per credential ID.Therefore, I couldn't find a way to limit this resource to the 'one api call'
-  principle. Instead, the terraform schema stores a list of associated credential ids. And, when creating or deleting or updated, it will make one api call PER
-  list element. This allows the import function to work by only needing to pass in one job template ID to fill out the entire resource. If this was not done this way
-  then when someone tries to to use the terraform plan -generate-config-out=./file.tf functionality it will create the resource block correctly. Otherwise, the
-  -generate-config-out function would have to generate several resource blocks per template id and it's not set up to do that, per my current awareness. As I'm writing this 				provider specifically so we can use the -generate-config-out option, I felt this was worth the price of breaking this principle. The downside seems to be that this means
-  if one of the list element's api calls succeeds, but a subsequent list element's fails, the success of the first element's call is not magially un-done.
-  So you'll perpas have to use refresh state functions in tf cli to resolve.
+  The /api/v2/job_templates/{id}/credentials/ returns all credential objects associated to the template. But, when asked to associate a credential or dissassociate a credential, you must post a request once per credential ID.Therefore, I couldn't find a way to limit this resource to the 'one api call' principle. Instead, the terraform schema stores a list of associated credential ids. And, when creating or deleting or updated, it will make one api call PER list element. This allows the import function to work by only needing to pass in one job template ID to fill out the entire resource. If this was not done this way then when someone tries to to use the terraform plan -generate-config-out=./file.tf functionality it will create the resource block correctly. Otherwise, the -generate-config-out function would have to generate several resource blocks per template id and it's not set up to do that, per my current awareness. As I'm writing this provider specifically so we can use the -generate-config-out option, I felt this was worth the price of breaking this principle. The downside seems to be that this means if one of the list element's api calls succeeds, but a subsequent list element's fails, the success of the first element's call is not magially un-done. So you'll perpas have to use refresh state functions in tf cli to resolve.
 ---
 
 # awx_job_template_credential (Resource)
 
-The /api/v2/job_templates/{id}/credentials/ returns all credential objects associated to the template. But, when asked to associate a credential or 
-					  dissassociate a credential, you must post a request once per credential ID.Therefore, I couldn't find a way to limit this resource to the 'one api call' 
-					  principle. Instead, the terraform schema stores a list of associated credential ids. And, when creating or deleting or updated, it will make one api call PER 
-					  list element. This allows the import function to work by only needing to pass in one job template ID to fill out the entire resource. If this was not done this way 
-					  then when someone tries to to use the terraform plan -generate-config-out=./file.tf functionality it will create the resource block correctly. Otherwise, the 
-					  -generate-config-out function would have to generate several resource blocks per template id and it's not set up to do that, per my current awareness. As I'm writing this 					  
-					  provider specifically so we can use the -generate-config-out option, I felt this was worth the price of breaking this principle. The downside seems to be that this means 
-					  if one of the list element's api calls succeeds, but a subsequent list element's fails, the success of the first element's call is not magially un-done. 
-					  So you'll perpas have to use refresh state functions in tf cli to resolve.
+The /api/v2/job_templates/{id}/credentials/ returns all credential objects associated to the template. But, when asked to associate a credential or dissassociate a credential, you must post a request once per credential ID.Therefore, I couldn't find a way to limit this resource to the 'one api call' principle. Instead, the terraform schema stores a list of associated credential ids. And, when creating or deleting or updated, it will make one api call PER list element. This allows the import function to work by only needing to pass in one job template ID to fill out the entire resource. If this was not done this way then when someone tries to to use the terraform plan -generate-config-out=./file.tf functionality it will create the resource block correctly. Otherwise, the -generate-config-out function would have to generate several resource blocks per template id and it's not set up to do that, per my current awareness. As I'm writing this provider specifically so we can use the -generate-config-out option, I felt this was worth the price of breaking this principle. The downside seems to be that this means if one of the list element's api calls succeeds, but a subsequent list element's fails, the success of the first element's call is not magially un-done. So you'll perpas have to use refresh state functions in tf cli to resolve.
 
 ## Example Usage
 

--- a/docs/resources/workflow_job_template.md
+++ b/docs/resources/workflow_job_template.md
@@ -59,7 +59,6 @@ resource "awx_workflow_job_templates" "example" {
 - `inventory` (Number)
 - `job_tags` (String)
 - `limit` (String)
-- `organization` (Number)
 - `scm_branch` (String)
 - `skip_tags` (String)
 - `survey_enabled` (Boolean)

--- a/docs/resources/workflow_job_template.md
+++ b/docs/resources/workflow_job_template.md
@@ -59,6 +59,7 @@ resource "awx_workflow_job_templates" "example" {
 - `inventory` (Number)
 - `job_tags` (String)
 - `limit` (String)
+- `organization` (Number)
 - `scm_branch` (String)
 - `skip_tags` (String)
 - `survey_enabled` (Boolean)

--- a/internal/provider/resource_job_template.go
+++ b/internal/provider/resource_job_template.go
@@ -977,15 +977,18 @@ func (r *JobTemplateResource) Read(ctx context.Context, req resource.ReadRequest
 
 	// data.CustomVirtualEnv = types.StringValue(responseData.CustomVirtualEnv)
 	if !(data.CustomVirtualEnv.IsNull() && responseData.CustomVirtualEnv == nil) {
-
-		if customVirtualEnv, ok := responseData.CustomVirtualEnv.(string); ok {
-			resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("custom_virtualenv"), customVirtualEnv)...)
+		if data.CustomVirtualEnv.ValueString() == "" && responseData.CustomVirtualEnv == nil {
+			resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("custom_virtualenv"), "")...)
 		} else {
-			resp.Diagnostics.AddError(
-				"Invalid Type",
-				"Expected responseData.CustomVirtualEnv to be a string",
-			)
-			return
+			if customVirtualEnv, ok := responseData.CustomVirtualEnv.(string); ok {
+				resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("custom_virtualenv"), customVirtualEnv)...)
+			} else {
+				resp.Diagnostics.AddError(
+					"Invalid Type",
+					"Expected responseData.CustomVirtualEnv to be a string",
+				)
+				return
+			}
 		}
 
 		if resp.Diagnostics.HasError() {

--- a/internal/provider/resource_job_template.go
+++ b/internal/provider/resource_job_template.go
@@ -151,11 +151,13 @@ func (r *JobTemplateResource) Schema(ctx context.Context, req resource.SchemaReq
 			"description": schema.StringAttribute{
 				Optional: true,
 				Default:  stringdefault.StaticString(""),
+				Computed: true,
 			},
 			"job_type": schema.StringAttribute{
 				Optional:    true,
 				Description: "Acceptable values are a choice of: run, or check.",
 				Default:     stringdefault.StaticString("run"),
+				Computed:    true,
 			},
 			"inventory": schema.Int32Attribute{
 				Optional:    true,
@@ -172,46 +174,57 @@ func (r *JobTemplateResource) Schema(ctx context.Context, req resource.SchemaReq
 			"scm_branch": schema.StringAttribute{
 				Optional: true,
 				Default:  stringdefault.StaticString(""),
+				Computed: true,
 			},
 			"forks": schema.Int32Attribute{
 				Optional: true,
 				Default:  int32default.StaticInt32(0),
+				Computed: true,
 			},
 			"limit": schema.StringAttribute{
 				Optional: true,
 				Default:  stringdefault.StaticString(""),
+				Computed: true,
 			},
 			"verbosity": schema.Int32Attribute{
 				Optional: true,
 				Default:  int32default.StaticInt32(0),
+				Computed: true,
 			},
 			"extra_vars": schema.StringAttribute{
 				Optional: true,
 				Default:  stringdefault.StaticString(""),
+				Computed: true,
 			},
 			"job_tags": schema.StringAttribute{
 				Optional: true,
 				Default:  stringdefault.StaticString(""),
+				Computed: true,
 			},
 			"force_handlers": schema.BoolAttribute{
 				Optional: true,
 				Default:  booldefault.StaticBool(false),
+				Computed: true,
 			},
 			"skip_tags": schema.StringAttribute{
 				Optional: true,
 				Default:  stringdefault.StaticString(""),
+				Computed: true,
 			},
 			"start_at_tags": schema.StringAttribute{
 				Optional: true,
 				Default:  stringdefault.StaticString(""),
+				Computed: true,
 			},
 			"timeout": schema.Int32Attribute{
 				Optional: true,
 				Default:  int32default.StaticInt32(0),
+				Computed: true,
 			},
 			"use_fact_cache": schema.BoolAttribute{
 				Optional: true,
 				Default:  booldefault.StaticBool(false),
+				Computed: true,
 			},
 			"execution_environment": schema.Int32Attribute{
 				Optional: true,
@@ -219,86 +232,107 @@ func (r *JobTemplateResource) Schema(ctx context.Context, req resource.SchemaReq
 			"host_config_key": schema.StringAttribute{
 				Optional: true,
 				Default:  stringdefault.StaticString(""),
+				Computed: true,
 			},
 			"ask_scm_branch_on_launch": schema.BoolAttribute{
 				Optional: true,
 				Default:  booldefault.StaticBool(false),
+				Computed: true,
 			},
 			"ask_diff_mode_on_launch": schema.BoolAttribute{
 				Optional: true,
 				Default:  booldefault.StaticBool(false),
+				Computed: true,
 			},
 			"ask_variables_on_launch": schema.BoolAttribute{
 				Optional: true,
 				Default:  booldefault.StaticBool(false),
+				Computed: true,
 			},
 			"ask_limit_on_launch": schema.BoolAttribute{
 				Optional: true,
 				Default:  booldefault.StaticBool(false),
+				Computed: true,
 			},
 			"ask_tags_on_launch": schema.BoolAttribute{
 				Optional: true,
 				Default:  booldefault.StaticBool(false),
+				Computed: true,
 			},
 			"ask_skip_tags_on_launch": schema.BoolAttribute{
 				Optional: true,
 				Default:  booldefault.StaticBool(false),
+				Computed: true,
 			},
 			"ask_job_type_on_launch": schema.BoolAttribute{
 				Optional: true,
 				Default:  booldefault.StaticBool(false),
+				Computed: true,
 			},
 			"ask_verbosity_on_launch": schema.BoolAttribute{
 				Optional: true,
 				Default:  booldefault.StaticBool(false),
+				Computed: true,
 			},
 			"ask_inventory_on_launch": schema.BoolAttribute{
 				Optional: true,
 				Default:  booldefault.StaticBool(false),
+				Computed: true,
 			},
 			"ask_credential_on_launch": schema.BoolAttribute{
 				Optional: true,
 				Default:  booldefault.StaticBool(false),
+				Computed: true,
 			},
 			"ask_execution_environment_on_launch": schema.BoolAttribute{
 				Optional: true,
 				Default:  booldefault.StaticBool(false),
+				Computed: true,
 			},
 			"ask_labels_on_launch": schema.BoolAttribute{
 				Optional: true,
 				Default:  booldefault.StaticBool(false),
+				Computed: true,
 			},
 			"ask_forks_on_launch": schema.BoolAttribute{
 				Optional: true,
 				Default:  booldefault.StaticBool(false),
+				Computed: true,
 			},
 			"ask_job_slice_count_on_launch": schema.BoolAttribute{
 				Optional: true,
 				Default:  booldefault.StaticBool(false),
+				Computed: true,
 			},
 			"ask_timeout_on_launch": schema.BoolAttribute{
 				Optional: true,
 				Default:  booldefault.StaticBool(false),
+				Computed: true,
 			},
 			"ask_instance_groups_on_launch": schema.BoolAttribute{
 				Optional: true,
 				Default:  booldefault.StaticBool(false),
+				Computed: true,
 			},
 			"survey_enabled": schema.BoolAttribute{
 				Optional: true,
 				Default:  booldefault.StaticBool(false),
+				Computed: true,
 			},
 			"become_enabled": schema.BoolAttribute{
 				Optional: true,
 				Default:  booldefault.StaticBool(false),
+				Computed: true,
 			},
 			"diff_mode": schema.BoolAttribute{
 				Optional: true,
 				Default:  booldefault.StaticBool(false),
+				Computed: true,
 			},
 			"allow_simultaneous": schema.BoolAttribute{
 				Optional: true,
 				Default:  booldefault.StaticBool(false),
+				Computed: true,
 			},
 			"custom_virtualenv": schema.StringAttribute{
 				Optional: true,
@@ -306,10 +340,12 @@ func (r *JobTemplateResource) Schema(ctx context.Context, req resource.SchemaReq
 			"job_slice_count": schema.Int32Attribute{
 				Optional: true,
 				Default:  int32default.StaticInt32(1),
+				Computed: true,
 			},
 			"webhook_service": schema.StringAttribute{
 				Optional: true,
 				Default:  stringdefault.StaticString(""),
+				Computed: true,
 			},
 			"webhook_credential": schema.StringAttribute{
 				Optional: true,
@@ -317,6 +353,7 @@ func (r *JobTemplateResource) Schema(ctx context.Context, req resource.SchemaReq
 			"prevent_instance_group_fallback": schema.BoolAttribute{
 				Optional: true,
 				Default:  booldefault.StaticBool(false),
+				Computed: true,
 			},
 		},
 	}

--- a/internal/provider/resource_job_template.go
+++ b/internal/provider/resource_job_template.go
@@ -12,7 +12,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -81,7 +84,6 @@ type JobTemplateResourceModel struct {
 }
 
 type JobTemplate struct {
-	Id                             int    `json:"id,omitempty"`
 	Name                           string `json:"name,omitempty"`
 	Description                    string `json:"description"`
 	JobType                        string `json:"job_type,omitempty"`
@@ -148,10 +150,12 @@ func (r *JobTemplateResource) Schema(ctx context.Context, req resource.SchemaReq
 			},
 			"description": schema.StringAttribute{
 				Optional: true,
+				Default:  stringdefault.StaticString(""),
 			},
 			"job_type": schema.StringAttribute{
-				Required:    true,
+				Optional:    true,
 				Description: "Acceptable values are a choice of: run, or check.",
+				Default:     stringdefault.StaticString("run"),
 			},
 			"inventory": schema.Int32Attribute{
 				Optional:    true,
@@ -167,117 +171,152 @@ func (r *JobTemplateResource) Schema(ctx context.Context, req resource.SchemaReq
 			},
 			"scm_branch": schema.StringAttribute{
 				Optional: true,
+				Default:  stringdefault.StaticString(""),
 			},
 			"forks": schema.Int32Attribute{
 				Optional: true,
+				Default:  int32default.StaticInt32(0),
 			},
 			"limit": schema.StringAttribute{
 				Optional: true,
+				Default:  stringdefault.StaticString(""),
 			},
 			"verbosity": schema.Int32Attribute{
 				Optional: true,
+				Default:  int32default.StaticInt32(0),
 			},
 			"extra_vars": schema.StringAttribute{
 				Optional: true,
+				Default:  stringdefault.StaticString(""),
 			},
 			"job_tags": schema.StringAttribute{
 				Optional: true,
+				Default:  stringdefault.StaticString(""),
 			},
 			"force_handlers": schema.BoolAttribute{
 				Optional: true,
+				Default:  booldefault.StaticBool(false),
 			},
 			"skip_tags": schema.StringAttribute{
 				Optional: true,
+				Default:  stringdefault.StaticString(""),
 			},
 			"start_at_tags": schema.StringAttribute{
 				Optional: true,
+				Default:  stringdefault.StaticString(""),
 			},
 			"timeout": schema.Int32Attribute{
 				Optional: true,
+				Default:  int32default.StaticInt32(0),
 			},
 			"use_fact_cache": schema.BoolAttribute{
 				Optional: true,
+				Default:  booldefault.StaticBool(false),
 			},
 			"execution_environment": schema.Int32Attribute{
 				Optional: true,
 			},
 			"host_config_key": schema.StringAttribute{
 				Optional: true,
+				Default:  stringdefault.StaticString(""),
 			},
 			"ask_scm_branch_on_launch": schema.BoolAttribute{
 				Optional: true,
+				Default:  booldefault.StaticBool(false),
 			},
 			"ask_diff_mode_on_launch": schema.BoolAttribute{
 				Optional: true,
+				Default:  booldefault.StaticBool(false),
 			},
 			"ask_variables_on_launch": schema.BoolAttribute{
 				Optional: true,
+				Default:  booldefault.StaticBool(false),
 			},
 			"ask_limit_on_launch": schema.BoolAttribute{
 				Optional: true,
+				Default:  booldefault.StaticBool(false),
 			},
 			"ask_tags_on_launch": schema.BoolAttribute{
 				Optional: true,
+				Default:  booldefault.StaticBool(false),
 			},
 			"ask_skip_tags_on_launch": schema.BoolAttribute{
 				Optional: true,
+				Default:  booldefault.StaticBool(false),
 			},
 			"ask_job_type_on_launch": schema.BoolAttribute{
 				Optional: true,
+				Default:  booldefault.StaticBool(false),
 			},
 			"ask_verbosity_on_launch": schema.BoolAttribute{
 				Optional: true,
+				Default:  booldefault.StaticBool(false),
 			},
 			"ask_inventory_on_launch": schema.BoolAttribute{
 				Optional: true,
+				Default:  booldefault.StaticBool(false),
 			},
 			"ask_credential_on_launch": schema.BoolAttribute{
 				Optional: true,
+				Default:  booldefault.StaticBool(false),
 			},
 			"ask_execution_environment_on_launch": schema.BoolAttribute{
 				Optional: true,
+				Default:  booldefault.StaticBool(false),
 			},
 			"ask_labels_on_launch": schema.BoolAttribute{
 				Optional: true,
+				Default:  booldefault.StaticBool(false),
 			},
 			"ask_forks_on_launch": schema.BoolAttribute{
 				Optional: true,
+				Default:  booldefault.StaticBool(false),
 			},
 			"ask_job_slice_count_on_launch": schema.BoolAttribute{
 				Optional: true,
+				Default:  booldefault.StaticBool(false),
 			},
 			"ask_timeout_on_launch": schema.BoolAttribute{
 				Optional: true,
+				Default:  booldefault.StaticBool(false),
 			},
 			"ask_instance_groups_on_launch": schema.BoolAttribute{
 				Optional: true,
+				Default:  booldefault.StaticBool(false),
 			},
 			"survey_enabled": schema.BoolAttribute{
 				Optional: true,
+				Default:  booldefault.StaticBool(false),
 			},
 			"become_enabled": schema.BoolAttribute{
 				Optional: true,
+				Default:  booldefault.StaticBool(false),
 			},
 			"diff_mode": schema.BoolAttribute{
 				Optional: true,
+				Default:  booldefault.StaticBool(false),
 			},
 			"allow_simultaneous": schema.BoolAttribute{
 				Optional: true,
+				Default:  booldefault.StaticBool(false),
 			},
 			"custom_virtualenv": schema.StringAttribute{
 				Optional: true,
 			},
 			"job_slice_count": schema.Int32Attribute{
 				Optional: true,
+				Default:  int32default.StaticInt32(1),
 			},
 			"webhook_service": schema.StringAttribute{
 				Optional: true,
+				Default:  stringdefault.StaticString(""),
 			},
 			"webhook_credential": schema.StringAttribute{
 				Optional: true,
 			},
 			"prevent_instance_group_fallback": schema.BoolAttribute{
 				Optional: true,
+				Default:  booldefault.StaticBool(false),
 			},
 		},
 	}

--- a/internal/provider/resource_job_template_credential.go
+++ b/internal/provider/resource_job_template_credential.go
@@ -55,15 +55,7 @@ func (r *JobTemplateCredentialResource) Metadata(ctx context.Context, req resour
 
 func (r *JobTemplateCredentialResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: `The /api/v2/job_templates/{id}/credentials/ returns all credential objects associated to the template. But, when asked to associate a credential or 
-					  dissassociate a credential, you must post a request once per credential ID.Therefore, I couldn't find a way to limit this resource to the 'one api call' 
-					  principle. Instead, the terraform schema stores a list of associated credential ids. And, when creating or deleting or updated, it will make one api call PER 
-					  list element. This allows the import function to work by only needing to pass in one job template ID to fill out the entire resource. If this was not done this way 
-					  then when someone tries to to use the terraform plan -generate-config-out=./file.tf functionality it will create the resource block correctly. Otherwise, the 
-					  -generate-config-out function would have to generate several resource blocks per template id and it's not set up to do that, per my current awareness. As I'm writing this 					  
-					  provider specifically so we can use the -generate-config-out option, I felt this was worth the price of breaking this principle. The downside seems to be that this means 
-					  if one of the list element's api calls succeeds, but a subsequent list element's fails, the success of the first element's call is not magially un-done. 
-					  So you'll perpas have to use refresh state functions in tf cli to resolve.`,
+		Description: `The /api/v2/job_templates/{id}/credentials/ returns all credential objects associated to the template. But, when asked to associate a credential or dissassociate a credential, you must post a request once per credential ID.Therefore, I couldn't find a way to limit this resource to the 'one api call' principle. Instead, the terraform schema stores a list of associated credential ids. And, when creating or deleting or updated, it will make one api call PER list element. This allows the import function to work by only needing to pass in one job template ID to fill out the entire resource. If this was not done this way then when someone tries to to use the terraform plan -generate-config-out=./file.tf functionality it will create the resource block correctly. Otherwise, the -generate-config-out function would have to generate several resource blocks per template id and it's not set up to do that, per my current awareness. As I'm writing this provider specifically so we can use the -generate-config-out option, I felt this was worth the price of breaking this principle. The downside seems to be that this means if one of the list element's api calls succeeds, but a subsequent list element's fails, the success of the first element's call is not magially un-done. So you'll perpas have to use refresh state functions in tf cli to resolve.`,
 		Attributes: map[string]schema.Attribute{
 			"job_template_id": schema.StringAttribute{
 				Required:    true,

--- a/internal/provider/resource_workflow_job_template.go
+++ b/internal/provider/resource_workflow_job_template.go
@@ -37,7 +37,6 @@ type WorkflowJobTemplatesResourceModel struct {
 	Name                 types.String `tfsdk:"name"`
 	Description          types.String `tfsdk:"description"`
 	ExtraVars            types.String `tfsdk:"extra_vars"`
-	Organization         types.Int32  `tfsdk:"organization"`
 	SurveyEnabled        types.Bool   `tfsdk:"survey_enabled"`
 	AllowSimultaneous    types.Bool   `tfsdk:"allow_simultaneous"`
 	AskVariablesOnLaunch types.Bool   `tfsdk:"ask_variables_on_launch"`
@@ -61,7 +60,6 @@ type WorkflowJobTemplateAPIModel struct {
 	Name                 string `json:"name"`
 	Description          string `json:"description"`
 	ExtraVars            string `json:"extra_vars"`
-	Organization         int    `json:"organization"`
 	SurveyEnabled        bool   `json:"survey_enabled"`
 	AllowSimultaneous    bool   `json:"allow_simultaneous"`
 	AskVariablesOnLaunch bool   `json:"ask_variables_on_launch"`
@@ -102,9 +100,6 @@ func (r *WorkflowJobTemplatesResource) Schema(ctx context.Context, req resource.
 				Optional: true,
 			},
 			"extra_vars": schema.StringAttribute{
-				Optional: true,
-			},
-			"organization": schema.Int32Attribute{
 				Optional: true,
 			},
 			"survey_enabled": schema.BoolAttribute{
@@ -198,9 +193,6 @@ func (r *WorkflowJobTemplatesResource) Create(ctx context.Context, req resource.
 	}
 	if !data.ExtraVars.IsNull() {
 		bodyData.ExtraVars = data.ExtraVars.ValueString()
-	}
-	if !data.Organization.IsNull() {
-		bodyData.Organization = int(data.Organization.ValueInt32())
 	}
 	if !data.SurveyEnabled.IsNull() {
 		bodyData.SurveyEnabled = data.SurveyEnabled.ValueBool()
@@ -400,13 +392,6 @@ func (r *WorkflowJobTemplatesResource) Read(ctx context.Context, req resource.Re
 		}
 	}
 
-	if !(data.Organization.IsNull() && responseData.Organization == 0) {
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("organization"), responseData.Organization)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-	}
-
 	if !(data.SurveyEnabled.IsNull() && responseData.SurveyEnabled) {
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("survey_enabled"), responseData.SurveyEnabled)...)
 		if resp.Diagnostics.HasError() {
@@ -530,7 +515,6 @@ func (r *WorkflowJobTemplatesResource) Update(ctx context.Context, req resource.
 	bodyData.Name = data.Name.ValueString()
 	bodyData.Description = data.Description.ValueString()
 	bodyData.ExtraVars = data.ExtraVars.ValueString()
-	bodyData.Organization = int(data.Organization.ValueInt32())
 	bodyData.SurveyEnabled = data.SurveyEnabled.ValueBool()
 	bodyData.AllowSimultaneous = data.AllowSimultaneous.ValueBool()
 	bodyData.AskVariablesOnLaunch = data.AskVariablesOnLaunch.ValueBool()

--- a/internal/provider/resource_workflow_job_template.go
+++ b/internal/provider/resource_workflow_job_template.go
@@ -37,6 +37,7 @@ type WorkflowJobTemplatesResourceModel struct {
 	Name                 types.String `tfsdk:"name"`
 	Description          types.String `tfsdk:"description"`
 	ExtraVars            types.String `tfsdk:"extra_vars"`
+	Organization         types.Int32  `tfsdk:"organization"`
 	SurveyEnabled        types.Bool   `tfsdk:"survey_enabled"`
 	AllowSimultaneous    types.Bool   `tfsdk:"allow_simultaneous"`
 	AskVariablesOnLaunch types.Bool   `tfsdk:"ask_variables_on_launch"`
@@ -60,6 +61,7 @@ type WorkflowJobTemplateAPIModel struct {
 	Name                 string `json:"name"`
 	Description          string `json:"description"`
 	ExtraVars            string `json:"extra_vars"`
+	Organization         int    `json:"organization"`
 	SurveyEnabled        bool   `json:"survey_enabled"`
 	AllowSimultaneous    bool   `json:"allow_simultaneous"`
 	AskVariablesOnLaunch bool   `json:"ask_variables_on_launch"`
@@ -100,6 +102,9 @@ func (r *WorkflowJobTemplatesResource) Schema(ctx context.Context, req resource.
 				Optional: true,
 			},
 			"extra_vars": schema.StringAttribute{
+				Optional: true,
+			},
+			"organization": schema.Int32Attribute{
 				Optional: true,
 			},
 			"survey_enabled": schema.BoolAttribute{
@@ -194,6 +199,9 @@ func (r *WorkflowJobTemplatesResource) Create(ctx context.Context, req resource.
 	if !data.ExtraVars.IsNull() {
 		bodyData.ExtraVars = data.ExtraVars.ValueString()
 	}
+	if !data.Organization.IsNull() {
+		bodyData.Organization = int(data.Organization.ValueInt32())
+	}
 	if !data.SurveyEnabled.IsNull() {
 		bodyData.SurveyEnabled = data.SurveyEnabled.ValueBool()
 	}
@@ -269,7 +277,6 @@ func (r *WorkflowJobTemplatesResource) Create(ctx context.Context, req resource.
 		return
 	}
 	if httpResp.StatusCode != 201 {
-
 		defer httpResp.Body.Close()
 		body, err := io.ReadAll(httpResp.Body)
 		if err != nil {
@@ -352,7 +359,6 @@ func (r *WorkflowJobTemplatesResource) Read(ctx context.Context, req resource.Re
 		return
 	}
 	if httpResp.StatusCode != 200 && httpResp.StatusCode != 404 {
-
 		defer httpResp.Body.Close()
 		body, err := io.ReadAll(httpResp.Body)
 		if err != nil {
@@ -407,6 +413,13 @@ func (r *WorkflowJobTemplatesResource) Read(ctx context.Context, req resource.Re
 
 	if !(data.ExtraVars.IsNull() && responseData.ExtraVars == "") {
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("extra_vars"), responseData.ExtraVars)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	if !(data.Organization.IsNull() && responseData.Organization == 0) {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("organization"), responseData.Organization)...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
@@ -535,6 +548,7 @@ func (r *WorkflowJobTemplatesResource) Update(ctx context.Context, req resource.
 	bodyData.Name = data.Name.ValueString()
 	bodyData.Description = data.Description.ValueString()
 	bodyData.ExtraVars = data.ExtraVars.ValueString()
+	bodyData.Organization = int(data.Organization.ValueInt32())
 	bodyData.SurveyEnabled = data.SurveyEnabled.ValueBool()
 	bodyData.AllowSimultaneous = data.AllowSimultaneous.ValueBool()
 	bodyData.AskVariablesOnLaunch = data.AskVariablesOnLaunch.ValueBool()

--- a/internal/provider/resource_workflow_job_template.go
+++ b/internal/provider/resource_workflow_job_template.go
@@ -269,9 +269,19 @@ func (r *WorkflowJobTemplatesResource) Create(ctx context.Context, req resource.
 		return
 	}
 	if httpResp.StatusCode != 201 {
+
+		defer httpResp.Body.Close()
+		body, err := io.ReadAll(httpResp.Body)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Unable read http request response body.",
+				err.Error())
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Bad request status code.",
-			fmt.Sprintf("Expected 201`, got %v. ", httpResp.StatusCode))
+			fmt.Sprintf("Expected 201, got %v with message %s. ", httpResp.StatusCode, body))
 		return
 	}
 
@@ -342,9 +352,19 @@ func (r *WorkflowJobTemplatesResource) Read(ctx context.Context, req resource.Re
 		return
 	}
 	if httpResp.StatusCode != 200 && httpResp.StatusCode != 404 {
+
+		defer httpResp.Body.Close()
+		body, err := io.ReadAll(httpResp.Body)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Unable read http request response body.",
+				err.Error())
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Bad request status code.",
-			fmt.Sprintf("Expected 200, got %v. ", httpResp.StatusCode))
+			fmt.Sprintf("Expected 200, got %v with message %s. ", httpResp.StatusCode, body))
 		return
 	}
 
@@ -560,9 +580,18 @@ func (r *WorkflowJobTemplatesResource) Update(ctx context.Context, req resource.
 		return
 	}
 	if httpResp.StatusCode != 200 {
+		defer httpResp.Body.Close()
+		body, err := io.ReadAll(httpResp.Body)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Unable read http request response body.",
+				err.Error())
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Bad request status code.",
-			fmt.Sprintf("Expected 200, got %v. ", httpResp.StatusCode))
+			fmt.Sprintf("Expected 200, got %v with message %s. ", httpResp.StatusCode, body))
 		return
 	}
 
@@ -605,9 +634,19 @@ func (r *WorkflowJobTemplatesResource) Delete(ctx context.Context, req resource.
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to delete got error: %s", err))
 	}
 	if httpResp.StatusCode != 204 {
+		defer httpResp.Body.Close()
+		body, err := io.ReadAll(httpResp.Body)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Unable read http request response body.",
+				err.Error())
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Bad request status code.",
-			fmt.Sprintf("Expected 204, got %v. ", httpResp.StatusCode))
+			fmt.Sprintf("Expected 204, got %v with message %s. ", httpResp.StatusCode, body))
+		return
 
 	}
 }


### PR DESCRIPTION
- add defaults to job_template schema
- fix data type bug when moving job template's custom_virtualenv attribute between other awx providers and this one
- stub out for workflow job template