### PR TITLE
Upgrades to job template survey spec & some child workflow job template resources

### DIFF
--- a/docs/resources/job_template_survey_spec.md
+++ b/docs/resources/job_template_survey_spec.md
@@ -69,7 +69,7 @@ Required:
 Optional:
 
 - `choices` (List of String) List of strings which define the choices users can make for multichoice or multiselect.
-- `default` (String) Default value for the survey question.
+- `default` (String) Default value for the survey question. Supply a value of "" when you want no default value, even for type values that are non-text-based.
 - `max` (Number) Maximum value, default `1024`.
 - `min` (Number) Minimum value, default `1024`.
 - `required` (Boolean) Set if the survey question is required, defaults to `false`.

--- a/docs/resources/workflow_job_template_node_always.md
+++ b/docs/resources/workflow_job_template_node_always.md
@@ -14,8 +14,8 @@ Specify a node ID and then a list of node IDs that should run when this one ends
 
 ```terraform
 resource "awx_workflow_job_template_node_always" "example_node_always" {
-  id               = 201
-  success_node_ids = [241, 914]
+  id              = 201
+  always_node_ids = [241, 914]
 }
 ```
 
@@ -25,7 +25,7 @@ resource "awx_workflow_job_template_node_always" "example_node_always" {
 ### Required
 
 - `always_node_ids` (Set of Number) An unordered list of Node IDs attached to this workflow template node that should run on successful completion of this node.
-- `node_id` (String) The ID of the containing workflow job template node.
+- `id` (String) The ID of the containing workflow job template node.
 
 ## Import
 

--- a/docs/resources/workflow_job_template_node_label.md
+++ b/docs/resources/workflow_job_template_node_label.md
@@ -14,6 +14,7 @@ Specify a node ID and then a list of the lable IDs that are associated to this n
 
 ```terraform
 resource "awx_workflow_job_template_node_label" "example_node_label" {
+  id        = 1
   label_ids = [322, 121]
 }
 ```

--- a/docs/resources/workflow_job_template_node_success.md
+++ b/docs/resources/workflow_job_template_node_success.md
@@ -14,8 +14,8 @@ Specify a node ID and then a list of node IDs that should run when this one ends
 
 ```terraform
 resource "awx_workflow_job_template_node_success" "example_node_success" {
-  id               = 201
-  success_node_ids = [241, 914]
+  id          = 201
+  success_ids = [241, 914]
 }
 ```
 

--- a/examples/resources/awx_workflow_job_template_node_always/resource.tf
+++ b/examples/resources/awx_workflow_job_template_node_always/resource.tf
@@ -1,4 +1,4 @@
 resource "awx_workflow_job_template_node_always" "example_node_always" {
-  id               = 201
-  success_node_ids = [241, 914]
+  id              = 201
+  always_node_ids = [241, 914]
 }

--- a/examples/resources/awx_workflow_job_template_node_label/resource.tf
+++ b/examples/resources/awx_workflow_job_template_node_label/resource.tf
@@ -1,3 +1,4 @@
 resource "awx_workflow_job_template_node_label" "example_node_label" {
+  id        = 1
   label_ids = [322, 121]
 }

--- a/examples/resources/awx_workflow_job_template_node_success/resource.tf
+++ b/examples/resources/awx_workflow_job_template_node_success/resource.tf
@@ -1,4 +1,4 @@
 resource "awx_workflow_job_template_node_success" "example_node_success" {
-  id               = 201
-  success_node_ids = [241, 914]
+  id          = 201
+  success_ids = [241, 914]
 }

--- a/internal/provider/resource_job_template.go
+++ b/internal/provider/resource_job_template.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -365,14 +364,14 @@ func (r *JobTemplateResource) Schema(ctx context.Context, req resource.SchemaReq
 	}
 }
 
-func (d JobTemplateResource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
-	return []resource.ConfigValidator{
-		resourcevalidator.ExactlyOneOf(
-			path.MatchRoot("inventory"),
-			path.MatchRoot("ask_inventory_on_launch"),
-		),
-	}
-}
+// func (d JobTemplateResource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
+// 	return []resource.ConfigValidator{
+// 		resourcevalidator.ExactlyOneOf(
+// 			path.MatchRoot("inventory"),
+// 			path.MatchRoot("ask_inventory_on_launch"),
+// 		),
+// 	}
+// }
 
 func (r *JobTemplateResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {

--- a/internal/provider/resource_workflow_job_template_node_always.go
+++ b/internal/provider/resource_workflow_job_template_node_always.go
@@ -30,7 +30,7 @@ type WorkflowJobTemplatesNodeAlwaysResource struct {
 
 // WorkflowJobTemplatesNodeAlwaysResourceModel describes the resource data model.
 type WorkflowJobTemplatesNodeAlwaysResourceModel struct {
-	NodeId        types.String `tfsdk:"node_id"`
+	Id            types.String `tfsdk:"id"`
 	AlwaysNodeIds types.Set    `tfsdk:"always_node_ids"`
 }
 
@@ -43,7 +43,7 @@ func (r *WorkflowJobTemplatesNodeAlwaysResource) Schema(ctx context.Context, req
 		Description: "Specify a node ID and then a list of node IDs that should run when this one ends in success.",
 
 		Attributes: map[string]schema.Attribute{
-			"node_id": schema.StringAttribute{
+			"id": schema.StringAttribute{
 				Required:    true,
 				Description: "The ID of the containing workflow job template node.",
 			},
@@ -85,11 +85,11 @@ func (r *WorkflowJobTemplatesNodeAlwaysResource) Create(ctx context.Context, req
 		return
 	}
 	// set url for create HTTP request
-	id, err := strconv.Atoi(data.NodeId.ValueString())
+	id, err := strconv.Atoi(data.Id.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable convert id from string to int",
-			fmt.Sprintf("Unable to convert id: %v. ", data.NodeId.ValueString()))
+			fmt.Sprintf("Unable to convert id: %v. ", data.Id.ValueString()))
 	}
 
 	url := r.client.endpoint + fmt.Sprintf("/api/v2/workflow_job_template_nodes/%d/always_nodes/", id)
@@ -130,11 +130,11 @@ func (r *WorkflowJobTemplatesNodeAlwaysResource) Read(ctx context.Context, req r
 	}
 
 	//set url for create HTTP request
-	id, err := strconv.Atoi(data.NodeId.ValueString())
+	id, err := strconv.Atoi(data.Id.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable convert id from string to int",
-			fmt.Sprintf("Unable to convert id: %v. ", data.NodeId.ValueString()))
+			fmt.Sprintf("Unable to convert id: %v. ", data.Id.ValueString()))
 		return
 	}
 	url := r.client.endpoint + fmt.Sprintf("/api/v2/workflow_job_template_nodes/%d/always_nodes/", id)
@@ -221,9 +221,9 @@ func (r *WorkflowJobTemplatesNodeAlwaysResource) Update(ctx context.Context, req
 		return
 	}
 
-	id, err := strconv.Atoi(data.NodeId.ValueString())
+	id, err := strconv.Atoi(data.Id.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("Converting ID to Int failed", fmt.Sprintf("Converting the job template id %s to int failed.", data.NodeId.ValueString()))
+		resp.Diagnostics.AddError("Converting ID to Int failed", fmt.Sprintf("Converting the job template id %s to int failed.", data.Id.ValueString()))
 		return
 	}
 
@@ -326,11 +326,11 @@ func (r *WorkflowJobTemplatesNodeAlwaysResource) Delete(ctx context.Context, req
 		return
 	}
 	// set url for create HTTP request
-	id, err := strconv.Atoi(data.NodeId.ValueString())
+	id, err := strconv.Atoi(data.Id.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Unable convert id from string to int",
-			fmt.Sprintf("Unable to convert id: %v. ", data.NodeId.ValueString()))
+			fmt.Sprintf("Unable to convert id: %v. ", data.Id.ValueString()))
 	}
 
 	url := r.client.endpoint + fmt.Sprintf("/api/v2/workflow_job_template_nodes/%d/always_nodes/", id)
@@ -358,5 +358,5 @@ func (r *WorkflowJobTemplatesNodeAlwaysResource) Delete(ctx context.Context, req
 }
 
 func (r *WorkflowJobTemplatesNodeAlwaysResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("node_id"), req, resp)
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }


### PR DESCRIPTION
- Make job template survey spec no longer set to replace if changed for all attributes. This resource will now behave like all other objects.
- For now, comment out a config validator for the Job Template resource. Need to discus with Alex about how to solve it permanently. Maybe we just let the `terraform plan -generate-config-out=./out.tf` populate both in order to implement a validation. Or, look into a validator that checks for ask = false or inventory <> 0 instead of One of those 2 at all.
- Change workflow job template node always to use ID instead of Node ID as the base id for import purposes