### PR TITLE
fix: provider config code had typo

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -135,7 +135,7 @@ func (p *awxProvider) Configure(ctx context.Context, req provider.ConfigureReque
 		username = data.Username.ValueString()
 	}
 
-	if data.Password.IsNull() {
+	if !data.Password.IsNull() {
 		password = data.Password.ValueString()
 	}
 


### PR DESCRIPTION
When configuring provider, it was not pulling the password from the terraform config file when users specified it in their configuration code. The provider code was missing a "not" operator.